### PR TITLE
Don't blow up on engines which don't support defineProperty

### DIFF
--- a/index.js
+++ b/index.js
@@ -139,14 +139,20 @@ ansiHTML.reset = function(){
  * Expose tags, including open and close.
  * @type {Object}
  */
-ansiHTML.tags = {
-  get open() {
-    return _openTags;
-  },
-  get close() {
-    return _closeTags;
-  }
-};
+ansiHTML.tags = {};
+
+if (Object.defineProperty) {
+  Object.defineProperty(ansiHTML.tags, "open", {
+    get: function() { return _openTags; }
+  });
+  Object.defineProperty(ansiHTML.tags, "close", {
+    get: function() { return _closeTags; }
+  });
+} else {
+  ansiHTML.tags.open = _openTags;
+  ansiHTML.tags.close = _closeTags;
+}
+
 
 function _setTags(colors) {
   // reset all


### PR DESCRIPTION
Hello, 

I'm a happy downstream user of this module for `webpack-hot-middleware`.

I had a request from a user (https://github.com/glenjamin/webpack-hot-middleware/issues/98) that the module not blow up in IE8, which it's currently doing because of the `get`/`set` syntax.

Would you consider merging this PR which falls back to non-properties when `defineProperty` isn't available?